### PR TITLE
[#79] Added docker publish GitHub action

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,42 @@
+name: Docker
+
+on:
+  push:
+    # Publish `main` as Docker `latest` image.
+    branches:
+      - main
+
+env:
+  IMAGE_NAME: al-showit
+
+jobs:
+  # Push image to GitHub Packages.
+  # See also https://docs.docker.com/docker-hub/builds/
+  push:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Log into registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+
+      - name: Build image
+        run: docker build . --file Dockerfile --build-arg PUBLIC_PATH=/prohlížíme --build-arg REACT_APP_SPARQL_ENDPOINT=https://xn--slovnk-7va.gov.cz/prohlizime/sluzby/db-server/repositories/termit --tag $IMAGE_NAME
+
+      - name: Push image
+        run: |
+          IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "main" ] && VERSION=latest
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,7 +7,9 @@ on:
       - main
 
 env:
-  IMAGE_NAME: al-showit
+  IMAGE_NAME: showit
+  PUBLIC_PATH: /prohlížíme
+  SPARQL_ENDPOINT: https://xn--slovnk-7va.gov.cz/prohlizime/sluzby/db-server/repositories/termit
 
 jobs:
   # Push image to GitHub Packages.
@@ -23,7 +25,7 @@ jobs:
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
 
       - name: Build image
-        run: docker build . --file Dockerfile --build-arg PUBLIC_PATH=/prohlížíme --build-arg REACT_APP_SPARQL_ENDPOINT=https://xn--slovnk-7va.gov.cz/prohlizime/sluzby/db-server/repositories/termit --tag $IMAGE_NAME
+        run: docker build . --file Dockerfile --build-arg PUBLIC_PATH=$PUBLIC_PATH --build-arg REACT_APP_SPARQL_ENDPOINT=$SPARQL_ENDPOINT --tag $IMAGE_NAME
 
       - name: Push image
         run: |


### PR DESCRIPTION
This GitHub action configuration should build a Docker image and push it to the repository. No way to test it untill we merge and push something.

Please note that the build step requires two arguments - subpath variable and SPARQL endpoint variable.